### PR TITLE
Added get_stats to fps.py AND modified _gather_cpu_usage to avoid cod…

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,14 +20,11 @@ def hello():
 @app.route('/fps/<package_name>', methods=['GET', 'POST'])
 def getfps(package_name):
     fps = FPS(package_name=package_name, duration=60, dumpfile="text",
-              print_latency=False, require_full_name=True)
-    frames = fps._get_recent_frames()
+              print_latency=False, require_full_name=False)
+    
+    stats = fps.get_stats([], True)  # Frameless, no frames given, possible error when getting frames
     if not fps.error:
-        if len(frames) < 3:
-            return
-        total = len(frames) - 1
-        dt = (frames[-1].vsync - frames[0].vsync) / 1000000000
-        avg = total / dt
+        avg = stats['avg']
         return jsonify(str(avg))
     else:
         return fps.error
@@ -36,8 +33,11 @@ def getfps(package_name):
 @app.route('/cpu/<package_name>', methods=['GET', 'POST'])
 def getcpu(package_name):
     cpu = CPU(package_id=package_name)
-    output = cpu._web_gather_cpu_usage()
-    return output
+    stats = cpu._web_gather_cpu_usage()
+    if cpu.error:
+        error = cpu.get_error()
+        return {'error': error}
+    return stats
 
 
 @app.route('/mem/<package_name>', methods=['GET', 'POST'])


### PR DESCRIPTION
fps.py
def get_stats(self, frames: List[Frame], frameless=False) -> dict:

get_stats() will do the calculations, this will keep the calc logic in one place without duplicating.
It will also take an optional bool, frameless to indicate if we have frames or not. (This helps with backward compatibility)
If frameless is True, _get_recent_frames() will be called which should only be called within the class.
Returns a dict of the values calculated.

cpu.py
web_gather_cpu_usage()
Calls _gather_cpu_usage()
If successful, it get the usage values from the last appened values in the arrays. (Since they were just previously appened)

_gather_cpu_usage()
This will now return True or False and set self.error to the error message
It only updates the values if there are no errors.
It returns true if no errors.

New optional parameter cmdLine=True, if True sys.exit(1) will be called when an error is encountered.
If cmdLine=False, the function will just set self.error with the error message and return False

main.py  ***Might be an app breaking change.***
/cpu/<packagename>
This now returns {error: msg} instead of str(msg) if there was an error.
